### PR TITLE
Fix App Version and Static File Detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ stats/_includes/db_conn.php
 
 # Ignore any temp or old directories
 stats/_old/
+stats/static.html
 
 # Ignore any generated image files
 stats/graphs/*.png

--- a/INSTALLING.md
+++ b/INSTALLING.md
@@ -77,3 +77,23 @@ value needs to point to the fully-qualified path of the appliation.
 
 This file needs to be copied or renamed to `s/r.php` and the database
 connection information needs to be filled out.
+
+## Static File Generation
+
+The application supports the ability to generate a static HTML file that can be
+served up in place of a dynamic version of the site. This was done to reduce
+load times due to the increasing load times of having everything on a single
+page.
+
+The `index.php` file detects if there is a `static.html` file and includes that
+in the output instead of including the `current.php` file, if the `static.html`
+file is newer than `current.php`.
+
+To generate the `static.html` file, run the following from the command line:
+
+```
+php current.php > static.html
+```
+
+This can be done via a cron job to refresh the `static.html` file on a
+scheduled basis.

--- a/stats/current.php
+++ b/stats/current.php
@@ -11,6 +11,9 @@
 // Set start page start time
 $plTime = microtime(true);
 
+// Set app version
+define('APP_VERSION', '2.5.0.1');
+
 // Set if the page should display all records and minimum year
 define('DISPLAY_ALL', true);
 define('DISPLAY_MIN_YEAR', 2003);

--- a/stats/index.php
+++ b/stats/index.php
@@ -12,6 +12,8 @@ if (file_exists(STATIC_FILE) && file_exists(DYNAMIC_FILE)) {
 	} else {
 		require_once(DYNAMIC_FILE);
 	}
+} else if (file_exists(DYNAMIC_FILE)) {
+	require_once(DYNAMIC_FILE);
 } else {
 	print 'Error: unable to load Wait Wait... Don\'t Tell Me! Statistics Page';
 }

--- a/stats/index.php
+++ b/stats/index.php
@@ -2,7 +2,6 @@
 # Copyright (c) 2007-2020 Linh Pham
 # wwdt.me_v2 is relased under the terms of the Apache License 2.0
 
-define('APP_VERSION', '2.5.0');
 define('STATIC_FILE', 'static.html');
 define('DYNAMIC_FILE', 'current.php');
 

--- a/stats/static.html
+++ b/stats/static.html
@@ -1,1 +1,0 @@
-<!-- Placeholder File -->


### PR DESCRIPTION
Fixed an issue where `APP_VERSION` doesn't get picked up if only calling `current.php` directly. Also fixed issue where `index.php` would fail on lack of a generated `static.html` file.

Also updated documentation to include file generation step